### PR TITLE
Fix 'and' when bitsets are flipped and are different sizes

### DIFF
--- a/bitset.js
+++ b/bitset.js
@@ -270,11 +270,16 @@
       var t = this['data'];
       var p = P['data'];
 
+      var p_ = P['_'];
+
       var pl = p.length - 1;
       var tl = t.length - 1;
 
-      for (var i = tl; i > pl; i--) {
-        t[i] = 0;
+      if (p_ == 0) {
+        // clear any bits set:
+        for (var i = tl; i > pl; i--) {
+          t[i] = 0;
+        }
       }
 
       for (; i >= 0; i--) {

--- a/tests/bitset.test.js
+++ b/tests/bitset.test.js
@@ -387,6 +387,21 @@ describe('BitSet', function() {
     assert.equal(bs.get(4) + bs.get(0), 2);
   });
 
+  it('should work with flipped bitset: and', function() {
+
+    var a = new BitSet(0);
+    var b = new BitSet(0);
+    a = a.set(1);
+    b = b.set(50);
+
+    var output = b.and(a.not());
+
+    // check bits are correctly set beyond length of a
+    assert.equal(1, output.get(50));
+    // check bits are correctly unset beyond length of a
+    assert.equal(0, output.get(51));
+  });
+
   it('should work with different length scales: and', function() {
 
     var a = new BitSet();


### PR DESCRIPTION
The behaviour of the bitset seems to change depending on whether a parameter is passed to the constructor.

```javascript
var x = new bitset().setRange(0,32);
var y = new bitset().set(1).not();
var z = new bitset(0).set(1).not();

// As we would expect the 32nd bit is still set:
x.clone().and(y).get(32) == true

// But when using z, the 32nd bit is no longer set:
x.clone().and(z).get(32) == false
```

I think I've tracked this down to https://github.com/infusion/BitSet.js/blob/b2336b8e98ec615e3f76428aee98f28e27f80a70/bitset.js#L277 and fixed it with this pull request.

I originally wrote this as:
```javascript
t[i] &= p_;
```

But in keeping with your aim of having a fast implementation, I assumed `p_` would either be 0 or -1, and so optimised the code around this assumption - please let me know if this is not the case