### PR TITLE
Fix exports so Babel will detect it properly

### DIFF
--- a/bitset.js
+++ b/bitset.js
@@ -996,7 +996,7 @@
       return BitSet;
     });
   } else if (typeof exports === 'object') {
-    Object.defineProperty(exports, "__esModule", { 'value': true });
+    Object.defineProperty(BitSet, "__esModule", { 'value': true });
     BitSet['default'] = BitSet;
     BitSet['BitSet'] = BitSet;
     module['exports'] = BitSet;


### PR DESCRIPTION
`exports` is just the initial `module.exports` before the module is executed, but it's `module.exports` that's returned from `require`, not `exports`, and so Babel will miss it.