### PR TITLE
docs: Fix simple typo, uniformally -> uniformly

### DIFF
--- a/bitset.js
+++ b/bitset.js
@@ -976,7 +976,7 @@
     // Create an bitset instance
     var s = Object.create(BitSet.prototype);
 
-    // Fill the vector with random data, uniformally distributed
+    // Fill the vector with random data, uniformly distributed
     for (var i = 0; i < len; i++) {
       t.push(Math.random() * 4294967296 | 0);
     }


### PR DESCRIPTION
There is a small typo in bitset.js.

Should read `uniformly` rather than `uniformally`.

